### PR TITLE
Add consecutive failure protection to DeskMoveEngine

### DIFF
--- a/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMoveEngineTests.cs
+++ b/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMoveEngineTests.cs
@@ -204,7 +204,34 @@ public class DeskMoveEngineTests
                                    cts.Token ) ;
 
         // Verify that the debug message is logged when the command fails
-        _logger.Received ( ).Debug ( "StartMoveAsync command failed: {Desired}" ,
-                                     Direction.Up ) ;
+        _logger.Received ( ).Debug ( "StartMoveAsync command failed: {Desired} (consecutive failures: {Count})" ,
+                                     Direction.Up ,
+                                     Arg.Any < int > ( ) ) ;
+    }
+
+    [ TestMethod ]
+    public async Task StartMoveAsync_ConsecutiveFailures_StopsAfterThreeFailures ( )
+    {
+        var sut = CreateSut ( ) ;
+
+        // Simulate failures in the Up command
+        _executor.Up ( ).Returns ( Task.FromResult ( false ) ) ;
+
+        sut.DelayInterval = TimeSpan.FromMilliseconds ( 10 ) ;
+
+        using var cts = new CancellationTokenSource ( 500 ) ;
+
+        await sut.StartMoveAsync ( Direction.Up ,
+                                   cts.Token ) ;
+
+        // Verify that Up was called exactly 3 times before stopping
+        await _executor.Received ( 3 ).Up ( ) ;
+
+        // Verify that a warning was logged
+        _logger.Received ( ).Warning ( "Stopping move due to {Count} consecutive failures" ,
+                                       3 ) ;
+
+        // Verify that the direction is reset to None
+        sut.CurrentDirection.Should ( ).Be ( Direction.None ) ;
     }
 }

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMoveEngine.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMoveEngine.cs
@@ -9,6 +9,8 @@ namespace Idasen.BluetoothLE.Linak.Control ;
 internal class DeskMoveEngine
     : IDeskMoveEngine
 {
+    private const int MaxConsecutiveFailures = 3 ;
+
     private readonly IDeskCommandExecutor _executor ;
     private readonly ILogger              _logger ;
 
@@ -56,6 +58,8 @@ internal class DeskMoveEngine
         _logger.Debug ( "Starting repeated move commands: {Desired}" ,
                         desired ) ;
 
+        var consecutiveFailures = 0 ;
+
         try
         {
             while ( ! cancellationToken.IsCancellationRequested &&
@@ -69,14 +73,38 @@ internal class DeskMoveEngine
                     var ok = await moveTask.ConfigureAwait ( false ) ;
 
                     if ( ! ok )
-                        _logger.Debug ( "StartMoveAsync command failed: {Desired}" ,
-                                        desired ) ;
+                    {
+                        consecutiveFailures++ ;
+                        _logger.Debug ( "StartMoveAsync command failed: {Desired} (consecutive failures: {Count})" ,
+                                        desired ,
+                                        consecutiveFailures ) ;
+
+                        if ( consecutiveFailures >= MaxConsecutiveFailures )
+                        {
+                            _logger.Warning ( "Stopping move due to {Count} consecutive failures" ,
+                                              consecutiveFailures ) ;
+                            break ;
+                        }
+                    }
+                    else
+                    {
+                        consecutiveFailures = 0 ; // Reset on success
+                    }
                 }
                 catch ( Exception ex )
                 {
+                    consecutiveFailures++ ;
                     _logger.Error ( ex ,
-                                    "StartMoveAsync command threw exception: {Desired}" ,
-                                    desired ) ;
+                                    "StartMoveAsync command threw exception: {Desired} (consecutive failures: {Count})" ,
+                                    desired ,
+                                    consecutiveFailures ) ;
+
+                    if ( consecutiveFailures >= MaxConsecutiveFailures )
+                    {
+                        _logger.Warning ( "Stopping move due to {Count} consecutive failures" ,
+                                          consecutiveFailures ) ;
+                        break ;
+                    }
                 }
 
                 await Task.Delay ( DelayInterval ,


### PR DESCRIPTION
- Stop move commands after 3 consecutive failures to prevent endless loops
- Reset failure counter on successful command execution
- Add comprehensive logging for failures and stop events
- Update and add unit tests for failure handling behavior

This prevents the endless loop issue when WriteValueAsync times out and the desk stops responding.