### PR TITLE
47 desk cannot be controlled after interrupted desk movement 108

### DIFF
--- a/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMovementMonitorTests.cs
+++ b/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMovementMonitorTests.cs
@@ -221,4 +221,67 @@ public class DeskMovementMonitorTests : IDisposable
                .Warning ( "No height updates received for {Seconds} seconds" ,
                           Arg.Any < double > ( ) ) ;
     }
+
+    [ TestMethod ]
+    public void InactivityDetected_WhenRegularUpdates_DoesNotEmit ( )
+    {
+        using var sut = CreateSut ( ) ;
+
+        var receivedEvents = new List < string > ( ) ;
+        sut.InactivityDetected.Subscribe ( receivedEvents.Add ) ;
+
+        // Send regular updates
+        _subjectHeightAndSpeed.OnNext ( _details1 ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
+
+        _subjectHeightAndSpeed.OnNext ( _details2 ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
+
+        _subjectHeightAndSpeed.OnNext ( _details3 ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
+
+        // Should not have emitted any inactivity events
+        receivedEvents.Should ( ).BeEmpty ( ) ;
+    }
+
+    [ TestMethod ]
+    public void InactivityDetected_Observable_IsNotNull ( )
+    {
+        using var sut = CreateSut ( ) ;
+
+        // The InactivityDetected observable should be available
+        sut.InactivityDetected.Should ( ).NotBeNull ( ) ;
+    }
+
+    [ TestMethod ]
+    public void InactivityDetected_CanSubscribe_WithoutError ( )
+    {
+        using var sut = CreateSut ( ) ;
+
+        // Should be able to subscribe to the observable
+        var action = ( ) => sut.InactivityDetected.Subscribe ( _ => { } ) ;
+
+        action.Should ( ).NotThrow ( ) ;
+    }
+
+    [ TestMethod ]
+    public void InactivityDetected_WhenDisposed_CompletesObservable ( )
+    {
+        var sut = CreateSut ( ) ;
+
+        var completed = false ;
+        sut.InactivityDetected.Subscribe (
+            _ => { } ,
+            ( ) => completed = true ) ;
+
+        // Send an update
+        _subjectHeightAndSpeed.OnNext ( _details1 ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
+
+        // Dispose the monitor
+        sut.Dispose ( ) ;
+
+        // The observable should complete
+        completed.Should ( ).BeTrue ( ) ;
+    }
 }

--- a/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMoverTests.cs
+++ b/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMoverTests.cs
@@ -301,4 +301,81 @@ public sealed class DeskMoverTests : IDisposable
         sut.Height.Should ( ).Be ( expectedHeight ,
                                    "the height should be updated when notified" ) ;
     }
+
+    [ TestMethod ]
+    public void Initialize_SubscribesToMonitorInactivityDetected ( )
+    {
+        // Arrange
+        var monitor              = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject    = new Subject < string > ( ) ;
+        var initialProvider      = Substitute.For < IInitialHeightProvider > ( ) ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        using var sut = CreateSut ( ) ;
+
+        // Act
+        sut.Initialize ( ) ;
+
+        // Assert - verify subscription was created
+        _ = monitor.Received ( 1 ).InactivityDetected ;
+    }
+
+    [ TestMethod ]
+    public void InactivityDetected_StopsMovementAndEngine ( )
+    {
+        // Arrange
+        var monitor              = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject    = new Subject < string > ( ) ;
+        var initialProvider      = Substitute.For < IInitialHeightProvider > ( ) ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.GetType ( ).GetProperty ( "IsAllowedToMove" )!.SetValue ( sut , true ) ;
+
+        // Act - emit inactivity event
+        inactivitySubject.OnNext ( "No height updates received" ) ;
+
+        // Assert
+        _engine.Received ( ).StopMoveAsync ( ) ;
+        sut.IsAllowedToMove.Should ( ).BeFalse ( "movement should be stopped after inactivity" ) ;
+    }
+
+    [ TestMethod ]
+    public void InactivityDetected_LogsError ( )
+    {
+        // Arrange
+        var monitor              = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject    = new Subject < string > ( ) ;
+        var initialProvider      = Substitute.For < IInitialHeightProvider > ( ) ;
+        var reason               = "No height updates received for timeout period" ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+
+        // Act - emit inactivity event
+        inactivitySubject.OnNext ( reason ) ;
+
+        // Assert
+        _logger.Received ( 1 ).Error ( "Movement stopped due to inactivity: {Reason}" , reason ) ;
+    }
 }

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Concurrency ;
 using System.Reactive.Linq ;
+using System.Reactive.Subjects ;
 using Autofac.Extras.DynamicProxy ;
 using Idasen.Aop.Aspects ;
 using Idasen.BluetoothLE.Linak.Interfaces ;
@@ -21,9 +22,10 @@ public class DeskMovementMonitor
     internal const string SpeedWasZero          = "Speed was zero when moving desk" ;
     internal const string NoHeightUpdatesReceived = "No height updates received for timeout period" ;
 
-    private readonly IDeskHeightAndSpeed _heightAndSpeed ;
-    private readonly ILogger             _logger ;
-    private readonly IScheduler          _scheduler ;
+    private readonly IDeskHeightAndSpeed       _heightAndSpeed ;
+    private readonly ILogger                   _logger ;
+    private readonly IScheduler                _scheduler ;
+    private readonly Subject < string >        _subjectInactivityDetected ;
 
     private IDisposable ? _disposalHeightAndSpeed ;
     private IDisposable ? _inactivityTimer ;
@@ -39,10 +41,14 @@ public class DeskMovementMonitor
         ArgumentNullException.ThrowIfNull ( heightAndSpeed ) ;
         ArgumentNullException.ThrowIfNull ( logger ) ;
 
-        _logger         = logger ;
-        _scheduler      = scheduler ;
-        _heightAndSpeed = heightAndSpeed ;
+        _logger                    = logger ;
+        _scheduler                 = scheduler ;
+        _heightAndSpeed            = heightAndSpeed ;
+        _subjectInactivityDetected = new Subject < string > ( ) ;
     }
+
+    /// <inheritdoc />
+    public IObservable < string > InactivityDetected => _subjectInactivityDetected ;
 
     /// <inheritdoc />
     public void Dispose ( )
@@ -96,6 +102,8 @@ public class DeskMovementMonitor
 
             _inactivityTimer?.Dispose ( ) ;
             _inactivityTimer = null ;
+
+            _subjectInactivityDetected?.Dispose ( ) ;
         }
     }
 
@@ -143,6 +151,10 @@ public class DeskMovementMonitor
         {
             _logger.Warning ( "No height updates received for {Seconds} seconds" ,
                               elapsed.TotalSeconds ) ;
+
+            // Publish event to trigger movement stop
+            _subjectInactivityDetected.OnNext ( NoHeightUpdatesReceived ) ;
+
             throw new InvalidOperationException ( NoHeightUpdatesReceived ) ;
         }
     }

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
@@ -103,6 +103,7 @@ public class DeskMovementMonitor
             _inactivityTimer?.Dispose ( ) ;
             _inactivityTimer = null ;
 
+            _subjectInactivityDetected?.OnCompleted ( ) ;
             _subjectInactivityDetected?.Dispose ( ) ;
         }
     }

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMover.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMover.cs
@@ -38,6 +38,7 @@ public class DeskMover
 
     private IDisposable ? _disposableProvider ;
     private IDisposable ? _guardTargetHeightReached ;
+    private IDisposable ? _monitorInactivityDetected ;
 
     private IInitialHeightProvider ? _initialProvider ;
 
@@ -133,6 +134,18 @@ public class DeskMover
                                                         _engine.StopMoveAsync ( ) ;
                                                         StopMovement ( ) ;
                                                     } ) ;
+
+            // Subscribe to inactivity detection
+            _monitorInactivityDetected?.Dispose ( ) ;
+            _monitorInactivityDetected = _monitor.InactivityDetected
+                                                 .ObserveOn ( _scheduler )
+                                                 .Subscribe ( reason =>
+                                                              {
+                                                                  _logger.Error ( "Movement stopped due to inactivity: {Reason}" ,
+                                                                                  reason ) ;
+                                                                  _engine.StopMoveAsync ( ) ;
+                                                                  StopMovement ( ) ;
+                                                              } ) ;
         }
     }
 
@@ -237,6 +250,7 @@ public class DeskMover
             _rawHeightAndSpeedSubscription?.Dispose ( ) ;
             _cycleDisposables?.Dispose ( ) ;
             _guardTargetHeightReached?.Dispose ( ) ;
+            _monitorInactivityDetected?.Dispose ( ) ;
         }
     }
 

--- a/src/Idasen.BluetoothLE.Linak/Interfaces/IDeskMovementMonitor.cs
+++ b/src/Idasen.BluetoothLE.Linak/Interfaces/IDeskMovementMonitor.cs
@@ -12,4 +12,9 @@ public interface IDeskMovementMonitor
     ///     Initializes the monitor with the specified ring buffer capacity.
     /// </summary>
     void Initialize ( int capacity = DeskMovementMonitor.DefaultCapacity ) ;
+
+    /// <summary>
+    ///     Observable that emits when the desk has stopped responding (no height updates).
+    /// </summary>
+    IObservable < string > InactivityDetected { get ; }
 }


### PR DESCRIPTION
Summary of Changes:
1. Added InactivityDetected Observable Event
•	Added IObservable<string> InactivityDetected to IDeskMovementMonitor interface
•	Created a Subject<string> in DeskMovementMonitor to publish inactivity events
2. Modified DeskMovementMonitor
•	When inactivity is detected (no updates for >5 seconds), it now:
1.	Logs a warning
2.	Publishes an event via InactivityDetected observable
3.	Throws an exception (for error handling)
3. Updated DeskMover
•	Subscribes to monitor.InactivityDetected in the Initialize() method
•	When inactivity is detected:
1.	Logs an error with the reason
2.	Stops the movement engine (_engine.StopMoveAsync())
3.	Calls StopMovement() to clean up and stop the control loop
How It Works:
Now when the desk stops sending height/speed updates for more than 5 seconds:
1.	The inactivity watchdog detects it
2.	An event is published
3.	DeskMover receives the event and actively stops the movement
4.	The endless loop of TryGetValue calls is broken