### PR TITLE
47 desk cannot be controlled after interrupted desk movement 108

### DIFF
--- a/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMovementMonitorTests.cs
+++ b/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMovementMonitorTests.cs
@@ -140,7 +140,7 @@ public class DeskMovementMonitorTests : IDisposable
         _subjectHeightAndSpeed.OnNext ( _details1 ) ;
         _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
 
-        // Advance time by 2 seconds
+        // Advance time by 2 seconds (within 3 second timeout)
         _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 2 ).Ticks ) ;
 
         // Send another update
@@ -206,15 +206,15 @@ public class DeskMovementMonitorTests : IDisposable
         _subjectHeightAndSpeed.OnNext ( _details1 ) ;
         _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
 
-        // Wait 4 seconds (just under timeout)
-        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 4 ).Ticks ) ;
+        // Wait 2 seconds (within 3 second timeout)
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 2 ).Ticks ) ;
 
         // Send another update (resets the timer)
         _subjectHeightAndSpeed.OnNext ( _details2 ) ;
         _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
 
-        // Wait another 4 seconds (total 9 seconds, but only 4 since last update)
-        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 4 ).Ticks ) ;
+        // Wait another 2 seconds (total 5 seconds, but only 2 since last update)
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 2 ).Ticks ) ;
 
         // Should not have thrown or logged
         _logger.DidNotReceive ( )

--- a/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMovementMonitorTests.cs
+++ b/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMovementMonitorTests.cs
@@ -284,4 +284,58 @@ public class DeskMovementMonitorTests : IDisposable
         // The observable should complete
         completed.Should ( ).BeTrue ( ) ;
     }
+
+    [ TestMethod ]
+    public void InactivityDetected_WhenNoUpdatesFor3Seconds_EmitsEvent ( )
+    {
+        using var sut = CreateSut ( ) ;
+
+        var receivedEvents = new List < string > ( ) ;
+        sut.InactivityDetected.Subscribe ( receivedEvents.Add ) ;
+
+        // Send initial update
+        _subjectHeightAndSpeed.OnNext ( _details1 ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
+
+        // Advance time by 4 seconds (exceeds 3 second timeout)
+        // Note: We need to catch the exception since CheckForInactivity throws
+        try
+        {
+            _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 4 ).Ticks ) ;
+        }
+        catch ( InvalidOperationException )
+        {
+            // Expected exception
+        }
+
+        // Should have emitted an inactivity event
+        receivedEvents.Should ( ).HaveCount ( 1 ) ;
+        receivedEvents [ 0 ].Should ( ).Be ( DeskMovementMonitor.NoHeightUpdatesReceived ) ;
+    }
+
+    [ TestMethod ]
+    public void InactivityTimer_WhenNoUpdatesFor3Seconds_LogsWarning ( )
+    {
+        using var sut = CreateSut ( ) ;
+
+        // Send initial update
+        _subjectHeightAndSpeed.OnNext ( _details1 ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
+
+        // Advance time by 4 seconds (exceeds 3 second timeout)
+        // Note: We need to catch the exception since CheckForInactivity throws
+        try
+        {
+            _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 4 ).Ticks ) ;
+        }
+        catch ( InvalidOperationException )
+        {
+            // Expected exception
+        }
+
+        // Should have logged a warning
+        _logger.Received ( 1 )
+               .Warning ( "No height updates received for {Seconds} seconds" ,
+                          Arg.Is < double > ( s => s > 3.0 ) ) ;
+    }
 }

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
@@ -81,7 +81,7 @@ public class DeskMovementMonitor
         // Start inactivity watchdog: check every 5 seconds if we've received updates
         _lastUpdateTime = _scheduler.Now ;
         _inactivityTimer?.Dispose ( ) ;
-        _inactivityTimer = Observable.Interval ( TimeSpan.FromSeconds ( 5 ) ,
+        _inactivityTimer = Observable.Interval ( TimeSpan.FromSeconds ( 1 ) ,
                                                  _scheduler )
                                      .Subscribe ( _ => CheckForInactivity ( ) ,
                                                   ex =>
@@ -91,6 +91,9 @@ public class DeskMovementMonitor
                                                       // Don't re-throw here as it would create unobserved task exception
                                                       // The exception is already logged and the monitor will be disposed
                                                   } ) ;
+
+        _logger.Information ( "DeskMovementMonitor initialized with {Capacity} capacity, inactivity watchdog started" ,
+                              capacity ) ;
     }
 
     protected virtual void Dispose ( bool disposing )
@@ -120,6 +123,10 @@ public class DeskMovementMonitor
     {
         _lastUpdateTime = _scheduler.Now ; // Update the last activity timestamp
 
+        _logger.Debug ( "Received height/speed update: Height={Height}, Speed={Speed}" ,
+                        details.Height ,
+                        details.Speed ) ;
+
         History.PushBack ( details ) ;
 
         _logger.Debug ( "History: {History}" ,
@@ -148,7 +155,10 @@ public class DeskMovementMonitor
     {
         var elapsed = _scheduler.Now - _lastUpdateTime ;
 
-        if ( elapsed.TotalSeconds > 5 )
+        _logger.Verbose ( "Inactivity check: {Elapsed} seconds since last update" ,
+                          elapsed.TotalSeconds ) ;
+
+        if ( elapsed.TotalSeconds > 3 )
         {
             _logger.Warning ( "No height updates received for {Seconds} seconds" ,
                               elapsed.TotalSeconds ) ;


### PR DESCRIPTION
These commits include:
•	Reduced inactivity check interval from 5 seconds to 1 second
•	Reduced timeout threshold from 5 seconds to 3 seconds
•	Enhanced logging (verbose, debug, and informational)
•	Added comprehensive unit tests for the new timeout behavior
•	All 982 tests passing