### PR TITLE
47 desk cannot be controlled after interrupted desk movement 108

### DIFF
--- a/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMovementMonitorTests.cs
+++ b/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMovementMonitorTests.cs
@@ -80,6 +80,7 @@ public class DeskMovementMonitorTests : IDisposable
                                             _heightAndSpeed ) ;
 
         sut.Initialize ( DefaultCapacity ) ;
+        sut.Start ( ) ; // Start the inactivity watchdog
 
         return sut ;
     }
@@ -380,7 +381,7 @@ public class DeskMovementMonitorTests : IDisposable
     }
 
     [ TestMethod ]
-    public void Initialize_ResetsInactivityDetection_ForNewCycle ( )
+    public void Start_ResetsInactivityDetection_ForNewCycle ( )
     {
         using var sut = CreateSut ( ) ;
 
@@ -395,8 +396,8 @@ public class DeskMovementMonitorTests : IDisposable
         // Should have emitted one event
         receivedEvents.Should ( ).HaveCount ( 1 ) ;
 
-        // Re-initialize for a new movement cycle
-        sut.Initialize ( ) ;
+        // Start a new movement cycle (resets inactivity detection)
+        sut.Start ( ) ;
 
         // Second cycle: Send update and wait for timeout
         _subjectHeightAndSpeed.OnNext ( _details2 ) ;
@@ -529,5 +530,82 @@ public class DeskMovementMonitorTests : IDisposable
         var action = ( ) => _scheduler.Start ( ) ;
 
         action.Should ( ).NotThrow ( ) ;
+    }
+
+    [ TestMethod ]
+    public void StopWatchdog_StopsInactivityTimer ( )
+    {
+        // Arrange
+        using var sut = CreateSut ( ) ;
+        var receivedEvents = new List < string > ( ) ;
+        sut.InactivityDetected.Subscribe ( receivedEvents.Add ) ;
+
+        // Act - stop the watchdog before timeout
+        _subjectHeightAndSpeed.OnNext ( _details1 ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
+        sut.StopWatchdog ( ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 5 ).Ticks ) ;
+
+        // Assert - no inactivity event should be emitted after stopping
+        receivedEvents.Should ( ).BeEmpty ( "watchdog was stopped before timeout" ) ;
+    }
+
+    [ TestMethod ]
+    public void StopWatchdog_CanBeCalledMultipleTimes ( )
+    {
+        // Arrange
+        using var sut = CreateSut ( ) ;
+
+        // Act
+        var act = ( ) =>
+        {
+            sut.StopWatchdog ( ) ;
+            sut.StopWatchdog ( ) ;
+            sut.StopWatchdog ( ) ;
+        } ;
+
+        // Assert
+        act.Should ( ).NotThrow ( "multiple calls to StopWatchdog should be safe" ) ;
+    }
+
+    [ TestMethod ]
+    public void StopWatchdog_ThenStart_RestartsWatchdog ( )
+    {
+        // Arrange
+        using var sut = CreateSut ( ) ;
+        var receivedEvents = new List < string > ( ) ;
+        sut.InactivityDetected.Subscribe ( receivedEvents.Add ) ;
+
+        // Act - start, stop, then start again
+        _subjectHeightAndSpeed.OnNext ( _details1 ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 1 ).Ticks ) ;
+        sut.StopWatchdog ( ) ;
+
+        // Start a new cycle
+        sut.Start ( ) ;
+        _scheduler.AdvanceBy ( TimeSpan.FromSeconds ( 4 ).Ticks ) ;
+
+        // Assert - should emit inactivity event after restart
+        receivedEvents.Should ( ).HaveCount ( 1 ) ;
+        receivedEvents [ 0 ].Should ( ).Be ( DeskMovementMonitor.NoHeightUpdatesReceived ) ;
+    }
+
+    [ TestMethod ]
+    public void StopWatchdog_WithoutStart_DoesNotThrow ( )
+    {
+        // Arrange
+        var sut = new DeskMovementMonitor ( _logger ,
+                                            _scheduler ,
+                                            _heightAndSpeed ) ;
+        sut.Initialize ( DefaultCapacity ) ;
+        // Note: not calling Start()
+
+        // Act
+        var act = ( ) => sut.StopWatchdog ( ) ;
+
+        // Assert
+        act.Should ( ).NotThrow ( "calling StopWatchdog without prior Start should be safe" ) ;
+
+        sut.Dispose ( ) ;
     }
 }

--- a/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMoverTests.cs
+++ b/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMoverTests.cs
@@ -378,4 +378,353 @@ public sealed class DeskMoverTests : IDisposable
         // Assert
         _logger.Received ( 1 ).Error ( "Movement stopped due to inactivity: {Reason}" , reason ) ;
     }
+
+    [ TestMethod ]
+    public void StartAfterReceivingCurrentHeight_CallsMonitorStart ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+        _calculator.MoveIntoDirection.Returns ( Direction.Up ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.TargetHeight = 1000 ; // Set a non-zero target
+
+        // Act - simulate initial height callback
+        var method = sut.GetType ( )
+                        .GetMethod ( "StartAfterReceivingCurrentHeight" ,
+                                    System.Reflection.BindingFlags.NonPublic |
+                                    System.Reflection.BindingFlags.Instance ) ;
+        method?.Invoke ( sut , [ 500u , 0 ] ) ;
+
+        // Assert
+        monitor.Received ( 1 ).Start ( ) ;
+    }
+
+    [ TestMethod ]
+    public void StartAfterReceivingCurrentHeight_StartsMonitorBeforeStartingEngine ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        var callOrder       = new List < string > ( ) ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+        _calculator.MoveIntoDirection.Returns ( Direction.Up ) ;
+
+        monitor.When ( m => m.Start ( ) )
+               .Do ( _ => callOrder.Add ( "MonitorStart" ) ) ;
+        _engine.When ( e => e.StartMoveAsync ( Arg.Any < Direction > ( ) ,
+                                              Arg.Any < CancellationToken > ( ) ) )
+               .Do ( _ => callOrder.Add ( "EngineStart" ) ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.TargetHeight = 1000 ;
+
+        // Act
+        var method = sut.GetType ( )
+                        .GetMethod ( "StartAfterReceivingCurrentHeight" ,
+                                    System.Reflection.BindingFlags.NonPublic |
+                                    System.Reflection.BindingFlags.Instance ) ;
+        method?.Invoke ( sut , [ 500u , 0 ] ) ;
+
+        // Assert
+        callOrder.Should ( ).HaveCount ( 2 ) ;
+        callOrder [ 0 ].Should ( ).Be ( "MonitorStart" ,
+                                      "monitor should start before engine" ) ;
+        callOrder [ 1 ].Should ( ).Be ( "EngineStart" ,
+                                      "engine should start after monitor" ) ;
+    }
+
+    [ TestMethod ]
+    public void StartAfterReceivingCurrentHeight_WhenTargetHeightIsZero_DoesNotStartMonitor ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+        _calculator.MoveIntoDirection.Returns ( Direction.Up ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.TargetHeight = 0 ; // Zero target should prevent movement
+
+        // Act - simulate initial height callback with zero target
+        var method = sut.GetType ( )
+                        .GetMethod ( "StartAfterReceivingCurrentHeight" ,
+                                    System.Reflection.BindingFlags.NonPublic |
+                                    System.Reflection.BindingFlags.Instance ) ;
+        method?.Invoke ( sut , [ 500u , 0 ] ) ;
+
+        // Assert - monitor.Start should not be called when TargetHeight is 0
+        monitor.DidNotReceive ( ).Start ( ) ;
+    }
+
+    [ TestMethod ]
+    public void StartAfterReceivingCurrentHeight_CallsMonitorStartOnEachMovementCycle ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+        _calculator.MoveIntoDirection.Returns ( Direction.Up ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.TargetHeight = 1000 ;
+
+        var method = sut.GetType ( )
+                        .GetMethod ( "StartAfterReceivingCurrentHeight" ,
+                                    System.Reflection.BindingFlags.NonPublic |
+                                    System.Reflection.BindingFlags.Instance ) ;
+
+        // Act - simulate multiple movement cycles
+        method?.Invoke ( sut , [ 500u , 0 ] ) ;
+        method?.Invoke ( sut , [ 700u , 0 ] ) ;
+        method?.Invoke ( sut , [ 900u , 0 ] ) ;
+
+        // Assert
+        monitor.Received ( 3 ).Start ( ) ;
+    }
+
+    [ TestMethod ]
+    public async Task StopMovement_CallsMonitorStopWatchdog ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.GetType ( ).GetProperty ( "IsAllowedToMove" )!.SetValue ( sut , true ) ;
+
+        // Act
+        await sut.StopMovement ( ) ;
+
+        // Assert
+        monitor.Received ( 1 ).StopWatchdog ( ) ;
+    }
+
+    [ TestMethod ]
+    public async Task StopMovement_StopsWatchdogBeforeEmittingFinished ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        var callOrder       = new List < string > ( ) ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        monitor.When ( m => m.StopWatchdog ( ) )
+               .Do ( _ => callOrder.Add ( "MonitorStop" ) ) ;
+        _subjectFinished.Subscribe ( _ => callOrder.Add ( "FinishedEmitted" ) ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.GetType ( ).GetProperty ( "IsAllowedToMove" )!.SetValue ( sut , true ) ;
+
+        // Act
+        await sut.StopMovement ( ) ;
+
+        // Assert
+        callOrder.Should ( ).HaveCount ( 2 ) ;
+        callOrder [ 0 ].Should ( ).Be ( "MonitorStop" ,
+                                      "monitor should stop before finished event" ) ;
+        callOrder [ 1 ].Should ( ).Be ( "FinishedEmitted" ,
+                                      "finished event should emit after monitor stops" ) ;
+    }
+
+    [ TestMethod ]
+    public async Task StopMovement_WhenAlreadyStopped_DoesNotCallMonitorStopWatchdog ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.GetType ( ).GetProperty ( "IsAllowedToMove" )!.SetValue ( sut , true ) ;
+
+        // Act - stop twice
+        await sut.StopMovement ( ) ;
+        monitor.ClearReceivedCalls ( ) ; // Clear the first call
+        await sut.StopMovement ( ) ;
+
+        // Assert - should not call StopWatchdog again when already stopped
+        monitor.DidNotReceive ( ).StopWatchdog ( ) ;
+    }
+
+    [ TestMethod ]
+    public void InactivityDetected_CallsMonitorStopWatchdog ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.GetType ( ).GetProperty ( "IsAllowedToMove" )!.SetValue ( sut , true ) ;
+
+        // Act - emit inactivity event
+        inactivitySubject.OnNext ( "No height updates received" ) ;
+
+        // Assert
+        monitor.Received ( 1 ).StopWatchdog ( ) ;
+    }
+
+    [ TestMethod ]
+    public void TargetHeightReached_CallsMonitorStopWatchdog ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        using var targetHeightSubject = new Subject < uint > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( targetHeightSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.GetType ( ).GetProperty ( "IsAllowedToMove" )!.SetValue ( sut , true ) ;
+
+        // Act - emit target height reached event
+        targetHeightSubject.OnNext ( 1000u ) ;
+
+        // Assert
+        monitor.Received ( 1 ).StopWatchdog ( ) ;
+    }
+
+    [ TestMethod ]
+    public void TargetHeightReached_CallsStopWatchdogAfterLogging ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        using var targetHeightSubject = new Subject < uint > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        var callOrder       = new List < string > ( ) ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( targetHeightSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        monitor.When ( m => m.StopWatchdog ( ) )
+               .Do ( _ => callOrder.Add ( "MonitorStop" ) ) ;
+        _logger.When ( l => l.Information ( "Reached target height={TargetHeight}" , Arg.Any < uint > ( ) ) )
+               .Do ( _ => callOrder.Add ( "LogInfo" ) ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.GetType ( ).GetProperty ( "IsAllowedToMove" )!.SetValue ( sut , true ) ;
+
+        // Act
+        targetHeightSubject.OnNext ( 1000u ) ;
+
+        // Assert - logging happens first, then StopMovement calls StopWatchdog
+        callOrder.Should ( ).HaveCount ( 2 ) ;
+        callOrder [ 0 ].Should ( ).Be ( "LogInfo" ,
+                                      "logging should happen first" ) ;
+        callOrder [ 1 ].Should ( ).Be ( "MonitorStop" ,
+                                      "monitor should stop after logging" ) ;
+    }
+
+    [ TestMethod ]
+    public void InactivityDetected_CallsStopWatchdogAfterLoggingError ( )
+    {
+        // Arrange
+        var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
+        using var inactivitySubject = new Subject < string > ( ) ;
+        var initialProvider = Substitute.For < IInitialHeightProvider > ( ) ;
+        var callOrder       = new List < string > ( ) ;
+        var reason          = "No height updates received" ;
+
+        _monitorFactory.Create ( _heightAndSpeed ).Returns ( monitor ) ;
+        _providerFactory.Create ( _executor , _heightAndSpeed ).Returns ( initialProvider ) ;
+        initialProvider!.Finished.Returns ( _finishedSubject ) ;
+        _heightAndSpeed.HeightAndSpeedChanged.Returns ( _heightAndSpeedChangedSubject ) ;
+        _guard.TargetHeightReached.Returns ( _finishedSubject ) ;
+        monitor.InactivityDetected.Returns ( inactivitySubject ) ;
+
+        monitor.When ( m => m.StopWatchdog ( ) )
+               .Do ( _ => callOrder.Add ( "MonitorStop" ) ) ;
+        _logger.When ( l => l.Error ( "Movement stopped due to inactivity: {Reason}" , Arg.Any < string > ( ) ) )
+               .Do ( _ => callOrder.Add ( "LogError" ) ) ;
+
+        using var sut = CreateSut ( ) ;
+        sut.Initialize ( ) ;
+        sut.GetType ( ).GetProperty ( "IsAllowedToMove" )!.SetValue ( sut , true ) ;
+
+        // Act
+        inactivitySubject.OnNext ( reason ) ;
+
+        // Assert - logging happens first, then StopMovement calls StopWatchdog
+        callOrder.Should ( ).HaveCount ( 2 ) ;
+        callOrder [ 0 ].Should ( ).Be ( "LogError" ,
+                                      "error logging should happen first" ) ;
+        callOrder [ 1 ].Should ( ).Be ( "MonitorStop" ,
+                                      "monitor should stop after logging error" ) ;
+    }
 }

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
@@ -62,6 +62,8 @@ public class DeskMovementMonitor
 
     /// <summary>
     ///     Initializes monitoring with the specified history capacity.
+    ///     Sets up the history buffer and subscribes to height/speed changes.
+    ///     Call Start() to begin the inactivity watchdog for a movement cycle.
     /// </summary>
     /// <param name="capacity">The number of samples to retain in history.</param>
     public void Initialize ( int capacity = DefaultCapacity )
@@ -80,10 +82,20 @@ public class DeskMovementMonitor
                                                               ex => _logger.Error ( ex ,
                                                                                     "Error observing height/speed changes" ) ) ;
 
-        // Reset inactivity detection flag
+        _logger.Information ( "DeskMovementMonitor initialized with {Capacity} capacity" ,
+                              capacity ) ;
+    }
+
+    /// <summary>
+    ///     Starts the inactivity watchdog timer for a new movement cycle.
+    ///     Resets the inactivity detection flag and begins monitoring for desk responsiveness.
+    /// </summary>
+    public void Start ( )
+    {
+        // Reset inactivity detection flag for new movement cycle
         _inactivityDetected = false ;
 
-        // Start inactivity watchdog: check every 5 seconds if we've received updates
+        // Start inactivity watchdog: check every second if we've received updates
         _lastUpdateTime = _scheduler.Now ;
         _inactivityTimer?.Dispose ( ) ;
         _inactivityTimer = Observable.Interval ( TimeSpan.FromSeconds ( 1 ) ,
@@ -97,13 +109,26 @@ public class DeskMovementMonitor
                                                   ex =>
                                                   {
                                                       _logger.Error ( ex ,
-                                                                      "Inactivity detected - desk stopped responding" ) ;
+                                                                      "Inactivity timer error" ) ;
                                                       // Don't re-throw here as it would create unobserved task exception
                                                       // The exception is already logged and the monitor will be disposed
                                                   } ) ;
 
-        _logger.Information ( "DeskMovementMonitor initialized with {Capacity} capacity, inactivity watchdog started" ,
-                              capacity ) ;
+        _logger.Information ( "Inactivity watchdog started for new movement cycle" ) ;
+    }
+
+    /// <summary>
+    ///     Stops the inactivity watchdog timer.
+    ///     This should be called when a movement cycle completes or is cancelled to clean up the timer.
+    /// </summary>
+    public void StopWatchdog ( )
+    {
+        _logger.Debug ( "Stopping inactivity watchdog" ) ;
+
+        _inactivityTimer?.Dispose ( ) ;
+        _inactivityTimer = null ;
+
+        _logger.Information ( "Inactivity watchdog stopped" ) ;
     }
 
     protected virtual void Dispose ( bool disposing )

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMovementMonitor.cs
@@ -88,7 +88,12 @@ public class DeskMovementMonitor
         _inactivityTimer?.Dispose ( ) ;
         _inactivityTimer = Observable.Interval ( TimeSpan.FromSeconds ( 1 ) ,
                                                  _scheduler )
-                                     .Subscribe ( _ => CheckForInactivity ( ) ,
+                                     .Subscribe ( tick =>
+                                                  {
+                                                      _logger.Debug ( "Inactivity timer tick {Tick}" ,
+                                                                      tick ) ;
+                                                      CheckForInactivity ( ) ;
+                                                  } ,
                                                   ex =>
                                                   {
                                                       _logger.Error ( ex ,
@@ -165,11 +170,14 @@ public class DeskMovementMonitor
     {
         // If we've already detected inactivity, don't check again
         if ( _inactivityDetected )
+        {
+            _logger.Debug ( "Inactivity already detected, skipping check" ) ;
             return ;
+        }
 
         var elapsed = _scheduler.Now - _lastUpdateTime ;
 
-        _logger.Verbose ( "Inactivity check: {Elapsed} seconds since last update" ,
+        _logger.Debug ( "Inactivity check: {Elapsed} seconds since last update" ,
                           elapsed.TotalSeconds ) ;
 
         if ( elapsed.TotalSeconds > 3 )

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMover.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMover.cs
@@ -272,6 +272,9 @@ public class DeskMover
             return ;
         }
 
+        // Reinitialize monitor for this movement cycle (resets inactivity detection)
+        _monitor?.Initialize ( ) ;
+
         // Compute initial start direction once for this cycle
         _calculator.Height                   = height ;
         _calculator.Speed                    = speed ;

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMover.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMover.cs
@@ -217,6 +217,9 @@ public class DeskMover
         _guard.StopGuarding ( ) ;
         _engine.StopMoveAsync ( ) ;
 
+        // Stop the inactivity watchdog when movement cycle completes
+        _monitor?.StopWatchdog ( ) ;
+
         _logger.Debug ( "Emitting finished (height={Height})" ,
                         Height ) ;
 
@@ -272,8 +275,8 @@ public class DeskMover
             return ;
         }
 
-        // Reinitialize monitor for this movement cycle (resets inactivity detection)
-        _monitor?.Initialize ( ) ;
+        // Start inactivity watchdog for this movement cycle
+        _monitor?.Start ( ) ;
 
         // Compute initial start direction once for this cycle
         _calculator.Height                   = height ;

--- a/src/Idasen.BluetoothLE.Linak/Interfaces/IDeskMovementMonitor.cs
+++ b/src/Idasen.BluetoothLE.Linak/Interfaces/IDeskMovementMonitor.cs
@@ -10,8 +10,21 @@ public interface IDeskMovementMonitor
 {
     /// <summary>
     ///     Initializes the monitor with the specified ring buffer capacity.
+    ///     This sets up the history buffer but does not start the inactivity timer.
     /// </summary>
     void Initialize ( int capacity = DeskMovementMonitor.DefaultCapacity ) ;
+
+    /// <summary>
+    ///     Starts the inactivity watchdog timer for a new movement cycle.
+    ///     This should be called at the beginning of each movement attempt.
+    /// </summary>
+    void Start ( ) ;
+
+    /// <summary>
+    ///     Stops the inactivity watchdog timer.
+    ///     This should be called when a movement cycle completes or is cancelled.
+    /// </summary>
+    void StopWatchdog ( ) ;
 
     /// <summary>
     ///     Observable that emits when the desk has stopped responding (no height updates).


### PR DESCRIPTION
The watchdog lifecycle is now fully tested across all scenarios:
•	Start → called at the beginning of each movement cycle
•	StopWatchdog → called when movement completes (success, inactivity, or manual stop)
•	Complete integration testing of the observable subscriptions and cleanup paths