### PR TITLE
Fix race condition in DeskMovementMonitor watchdog timer

### DIFF
--- a/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMoverTests.cs
+++ b/src/Idasen.BluetoothLE.Linak.Tests/Control/DeskMoverTests.cs
@@ -655,7 +655,7 @@ public sealed class DeskMoverTests : IDisposable
     }
 
     [ TestMethod ]
-    public void TargetHeightReached_CallsStopWatchdogAfterLogging ( )
+    public void TargetHeightReached_CallsStopWatchdogBeforeEngineStop ( )
     {
         // Arrange
         var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
@@ -673,6 +673,8 @@ public sealed class DeskMoverTests : IDisposable
 
         monitor.When ( m => m.StopWatchdog ( ) )
                .Do ( _ => callOrder.Add ( "MonitorStop" ) ) ;
+        _engine.When ( e => e.StopMoveAsync ( ) )
+               .Do ( _ => callOrder.Add ( "EngineStop" ) ) ;
         _logger.When ( l => l.Information ( "Reached target height={TargetHeight}" , Arg.Any < uint > ( ) ) )
                .Do ( _ => callOrder.Add ( "LogInfo" ) ) ;
 
@@ -683,16 +685,18 @@ public sealed class DeskMoverTests : IDisposable
         // Act
         targetHeightSubject.OnNext ( 1000u ) ;
 
-        // Assert - logging happens first, then StopMovement calls StopWatchdog
-        callOrder.Should ( ).HaveCount ( 2 ) ;
+        // Assert - monitor should stop before engine to prevent race condition
+        callOrder.Should ( ).HaveCount ( 3 ) ;
         callOrder [ 0 ].Should ( ).Be ( "LogInfo" ,
                                       "logging should happen first" ) ;
         callOrder [ 1 ].Should ( ).Be ( "MonitorStop" ,
-                                      "monitor should stop after logging" ) ;
+                                      "monitor should stop before engine" ) ;
+        callOrder [ 2 ].Should ( ).Be ( "EngineStop" ,
+                                      "engine should stop after monitor" ) ;
     }
 
     [ TestMethod ]
-    public void InactivityDetected_CallsStopWatchdogAfterLoggingError ( )
+    public void InactivityDetected_CallsStopWatchdogBeforeEngineStop ( )
     {
         // Arrange
         var monitor         = Substitute.For < IDeskMovementMonitor > ( ) ;
@@ -710,6 +714,8 @@ public sealed class DeskMoverTests : IDisposable
 
         monitor.When ( m => m.StopWatchdog ( ) )
                .Do ( _ => callOrder.Add ( "MonitorStop" ) ) ;
+        _engine.When ( e => e.StopMoveAsync ( ) )
+               .Do ( _ => callOrder.Add ( "EngineStop" ) ) ;
         _logger.When ( l => l.Error ( "Movement stopped due to inactivity: {Reason}" , Arg.Any < string > ( ) ) )
                .Do ( _ => callOrder.Add ( "LogError" ) ) ;
 
@@ -720,11 +726,13 @@ public sealed class DeskMoverTests : IDisposable
         // Act
         inactivitySubject.OnNext ( reason ) ;
 
-        // Assert - logging happens first, then StopMovement calls StopWatchdog
-        callOrder.Should ( ).HaveCount ( 2 ) ;
+        // Assert - monitor should stop before engine to prevent race condition
+        callOrder.Should ( ).HaveCount ( 3 ) ;
         callOrder [ 0 ].Should ( ).Be ( "LogError" ,
                                       "error logging should happen first" ) ;
         callOrder [ 1 ].Should ( ).Be ( "MonitorStop" ,
-                                      "monitor should stop after logging error" ) ;
+                                      "monitor should stop before engine" ) ;
+        callOrder [ 2 ].Should ( ).Be ( "EngineStop" ,
+                                      "engine should stop after monitor" ) ;
     }
 }

--- a/src/Idasen.BluetoothLE.Linak/Control/DeskMover.cs
+++ b/src/Idasen.BluetoothLE.Linak/Control/DeskMover.cs
@@ -131,7 +131,6 @@ public class DeskMover
                                                     {
                                                         _logger.Information ( "Reached target height={TargetHeight}" ,
                                                                               targetHeight ) ;
-                                                        _engine.StopMoveAsync ( ) ;
                                                         StopMovement ( ) ;
                                                     } ) ;
 
@@ -143,7 +142,6 @@ public class DeskMover
                                                               {
                                                                   _logger.Error ( "Movement stopped due to inactivity: {Reason}" ,
                                                                                   reason ) ;
-                                                                  _engine.StopMoveAsync ( ) ;
                                                                   StopMovement ( ) ;
                                                               } ) ;
         }
@@ -208,6 +206,9 @@ public class DeskMover
             return Task.FromResult ( true ) ;
         }
 
+        // Stop the inactivity watchdog FIRST to prevent race condition with timer
+        _monitor?.StopWatchdog ( ) ;
+
         IsAllowedToMove               = false ;
         _calculator.MoveIntoDirection = Direction.None ;
 
@@ -216,9 +217,6 @@ public class DeskMover
 
         _guard.StopGuarding ( ) ;
         _engine.StopMoveAsync ( ) ;
-
-        // Stop the inactivity watchdog when movement cycle completes
-        _monitor?.StopWatchdog ( ) ;
 
         _logger.Debug ( "Emitting finished (height={Height})" ,
                         Height ) ;


### PR DESCRIPTION
- Stop watchdog timer before engine stops to prevent false inactivity warnings
- Move StopWatchdog() call after early return check in StopMovement()
- Remove duplicate engine.StopMoveAsync() calls from subscription handlers
- Update tests to verify correct call order (watchdog stops before engine)
- Rename tests to reflect new behavior expectations
- All 52 tests passing (25 DeskMover + 27 DeskMovementMonitor)

Fixes #47